### PR TITLE
Scripting Update

### DIFF
--- a/CatEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/CatEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -526,8 +526,6 @@ namespace CatEngine
 								scriptInstance->SetFieldData(name, &data);
 							break;
 						}
-						case ScriptFieldType::Byte:
-							break;
 						case ScriptFieldType::UInt16:
 						{
 							uint16_t data = scriptInstance->GetFieldData<uint16_t>(name);
@@ -673,8 +671,6 @@ namespace CatEngine
 								}
 								break;
 							}
-							case ScriptFieldType::Byte:
-								break;
 							case ScriptFieldType::UInt16:
 							{
 								ScriptFieldInstance& scriptFieldInstance = scriptFields.at(name);
@@ -828,8 +824,6 @@ namespace CatEngine
 								}
 								break;
 							}
-							case ScriptFieldType::Byte:
-								break;
 							case ScriptFieldType::UInt16:
 							{
 								uint16_t data = 0;

--- a/CatEngine/CMakeLists.txt
+++ b/CatEngine/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SRCS
     src/CatEngine/Scene/SceneSerializer.cpp
     src/CatEngine/Scene/Components/Components.cpp
     src/CatEngine/Scene/SceneCamera.cpp
+    src/CatEngine/Scene/ContactListener.cpp
     src/CatEngine/Scene/Entity.cpp
     src/CatEngine/Core/Input.cpp
     src/CatEngine/Core/Window.cpp
@@ -110,6 +111,7 @@ set(SRCS
     src/CatEngine/Scene/Scene.h
     src/CatEngine/Scene/Entity.h
     src/CatEngine/Scene/ScriptObject.h
+    src/CatEngine/Scene/ContactListener.h
     src/CatEngine/Scene/Components/3D/TransformComponent.h
     src/CatEngine/Scene/Components/Required/InformationComponents.h
     src/CatEngine/Scene/Components/Renderer/CameraComponent.h

--- a/CatEngine/src/CatEngine/Scene/ContactListener.cpp
+++ b/CatEngine/src/CatEngine/Scene/ContactListener.cpp
@@ -1,0 +1,22 @@
+#include "cepch.h"
+#include "ContactListener.h"
+
+#include "CatEngine/Scripting/ScriptEngine.h"
+
+namespace CatEngine
+{
+    void ContactListener::BeginContact(b2Contact* contact)
+    {
+        const auto& handleA = static_cast<UUID>(contact->GetFixtureA()->GetUserData().pointer);
+        const auto& handleB = static_cast<UUID>(contact->GetFixtureB()->GetUserData().pointer);
+
+        ScriptEngine::DispatchCollisionEvent(handleA, handleB, CollisionType::Begin);
+    }
+    void ContactListener::EndContact(b2Contact* contact)
+    {
+        const auto& handleA = static_cast<UUID>(contact->GetFixtureA()->GetUserData().pointer);
+        const auto& handleB = static_cast<UUID>(contact->GetFixtureB()->GetUserData().pointer);
+
+        ScriptEngine::DispatchCollisionEvent(handleA, handleB, CollisionType::End);
+    }
+}

--- a/CatEngine/src/CatEngine/Scene/ContactListener.h
+++ b/CatEngine/src/CatEngine/Scene/ContactListener.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <box2d/box2d.h>
+
+namespace CatEngine
+{
+    class ContactListener : public b2ContactListener
+    {
+    public:
+        void BeginContact(b2Contact* contact) override;
+        void EndContact(b2Contact* contact) override;
+    };
+}

--- a/CatEngine/src/CatEngine/Scene/Scene.cpp
+++ b/CatEngine/src/CatEngine/Scene/Scene.cpp
@@ -6,6 +6,7 @@
 
 #include "CatEngine/Renderer/Renderer2D.h"
 
+#include <cstdint>
 #include <glm/glm.hpp>
 
 #include <box2d/b2_world.h>
@@ -218,29 +219,8 @@ namespace CatEngine
 				}
 			}
 			// Physics 2D
+            OnPhysics2DUpdate(time);
 
-			{
-				const int32_t velocityIterations = 6;
-				const int32_t positionIterations = 6;
-
-				m_PhysicsWorld->Step(time.deltaTime(), velocityIterations, positionIterations);
-
-				// Retrieve transform from Box2D
-				auto view = m_Registry.view<Rigidbody2DComponent>();
-				for (auto e : view)
-				{
-					Entity entity{ e, this };
-					auto& transform = entity.GetComponent<TransformComponent>();
-					auto& rb2d = entity.GetComponent<Rigidbody2DComponent>();
-                    
-					b2Body* body = (b2Body*)rb2d.RuntimeBody;
-					const auto& position = body->GetPosition();
-					transform.Position.x = position.x;
-					transform.Position.y = position.y;
-					transform.Rotation.z = body->GetAngle();
-				}
-
-			}
 		}
 		// Render 2D 
 		Camera* mainCamera = nullptr;
@@ -385,6 +365,7 @@ namespace CatEngine
 		CE_PROFILE_FUNCTION();
 
 		m_PhysicsWorld = new b2World({ 0.0f, -9.8f });
+        m_PhysicsWorld->SetContactListener(&m_ContactListenter);
         auto view = m_Registry.view<Rigidbody2DComponent>();
 		for (auto e : view)
 		{
@@ -413,6 +394,7 @@ namespace CatEngine
                 fixtureDef.friction = bc2d.Friction;
                 fixtureDef.restitution = bc2d.Restitution;
                 fixtureDef.restitutionThreshold = bc2d.RestitutionThreshold;
+                fixtureDef.userData.pointer = static_cast<uintptr_t>(entity.GetUUID());
                 body->CreateFixture(&fixtureDef);
             }
     
@@ -432,6 +414,30 @@ namespace CatEngine
                 fixtureDef.restitutionThreshold = cc2d.RestitutionThreshold;
                 body->CreateFixture(&fixtureDef);
             }
+        }
+
+    }
+
+    void Scene::OnPhysics2DUpdate(Time ts)
+    {
+        const int32_t velocityIterations = 6;
+        const int32_t positionIterations = 6;
+
+        m_PhysicsWorld->Step(ts.deltaTime(), velocityIterations, positionIterations);
+
+        // Retrieve transform from Box2D
+        auto view = m_Registry.view<Rigidbody2DComponent>();
+        for (auto e : view)
+        {
+            Entity entity{ e, this };
+            auto& transform = entity.GetComponent<TransformComponent>();
+            auto& rb2d = entity.GetComponent<Rigidbody2DComponent>();
+
+            b2Body* body = (b2Body*)rb2d.RuntimeBody;
+            const auto& position = body->GetPosition();
+            transform.Position.x = position.x;
+            transform.Position.y = position.y;
+            transform.Rotation.z = body->GetAngle();
         }
 
     }
@@ -462,7 +468,7 @@ namespace CatEngine
 	{
 		CE_PROFILE_FUNCTION();
 
-		Entity newEntity = CreateEntity(entity.GetName() + "(Copied from " + entity.GetName() + ")");
+		Entity newEntity = CreateEntity(entity.GetName() + "(Copy)");
 		CopyComponentIfExists(AllComponents{}, newEntity, entity);
 		return newEntity;
 	}

--- a/CatEngine/src/CatEngine/Scene/Scene.h
+++ b/CatEngine/src/CatEngine/Scene/Scene.h
@@ -7,6 +7,7 @@
 #include "CatEngine/Core/UUID.h"
 
 #include "CatEngine/AssetManager/Asset.h"
+#include "CatEngine/Scene/ContactListener.h"
 
 class b2World;
 
@@ -22,7 +23,6 @@ namespace CatEngine
         ~Scene();
 
 		static Ref<Scene> Copy(Ref<Scene> other);
-
 
 		Entity CreateEntity(const std::string& name = std::string());
 		Entity CreateEntityWithUUID(UUID uuid, const std::string& name = std::string());
@@ -62,6 +62,7 @@ namespace CatEngine
 
         bool IsRunning() { return m_IsRunning; }
 
+
         static AssetType GetStaticType() { return AssetType::Scene; }
         virtual AssetType GetType() const { return GetStaticType(); }
 
@@ -70,6 +71,7 @@ namespace CatEngine
 		    void OnComponentAdded(Entity entity, T& component);
 
 		void OnPhysics2DStart();
+        void OnPhysics2DUpdate(Time ts);
 		void OnPhysics2DStop();
 
         void OnScriptStart();
@@ -80,6 +82,7 @@ namespace CatEngine
         std::unordered_map<UUID, entt::entity> m_EntityMap;
 
         b2World* m_PhysicsWorld = nullptr;
+        ContactListener m_ContactListenter;
 
 		bool m_IsRunning = false;
 		bool m_IsPaused = false;

--- a/CatEngine/src/CatEngine/Scripting/CatScriptCore.h
+++ b/CatEngine/src/CatEngine/Scripting/CatScriptCore.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "CatEngine/Scene/Components/3D/TransformComponent.h"
+#include "CatEngine/Scene/Components/Physics/Rigidbody2D.h"
 #include "IScriptObject.h"
+#include "glm/fwd.hpp"
+#include <cstdint>
 
 namespace CatEngine
 {
@@ -14,7 +18,7 @@ namespace CatEngine
 		None = 0,
 		Float, Double,
 		SByte, Char, Int16, Int32, Int64, Boolean,
-		Byte, UInt16, UInt32, UInt64,
+		UInt16, UInt32, UInt64,
 		String,
 		Vector2, Vector3, Vector4,
 		TransformComponent, Rigidbody2DComponent,
@@ -58,4 +62,29 @@ namespace CatEngine
 		friend class ScriptEngine;
 		friend class ScriptInstance;
 	};
+
+    static size_t TypeToSize(const ScriptFieldType& type)
+    {
+        switch (type) 
+        {
+            case ScriptFieldType::Float: return sizeof(float);
+            case ScriptFieldType::Double: return sizeof(double);
+            case ScriptFieldType::SByte: return sizeof(int8_t);
+            case ScriptFieldType::Char: return sizeof(char);
+            case ScriptFieldType::Int16: return sizeof(int16_t);
+            case ScriptFieldType::Int32: return sizeof(int32_t);
+            case ScriptFieldType::Int64: return sizeof(int64_t);
+            case ScriptFieldType::Boolean: return sizeof(bool);
+            case ScriptFieldType::UInt16: return sizeof(uint16_t);
+            case ScriptFieldType::UInt32: return sizeof(uint32_t);
+            case ScriptFieldType::UInt64: return sizeof(uint64_t);
+            case ScriptFieldType::String: return sizeof(std::string);
+            case ScriptFieldType::Vector2: return sizeof(glm::vec2);
+            case ScriptFieldType::Vector3: return sizeof(glm::vec3);
+            case ScriptFieldType::Vector4: return sizeof(glm::vec4);
+            case ScriptFieldType::TransformComponent: return sizeof(TransformComponent);
+            case ScriptFieldType::Rigidbody2DComponent: return sizeof(Rigidbody2DComponent);
+            default : return 0;
+        }
+    }
 }

--- a/CatEngine/src/CatEngine/Scripting/CatScriptCore.h
+++ b/CatEngine/src/CatEngine/Scripting/CatScriptCore.h
@@ -30,6 +30,7 @@ namespace CatEngine
 	struct ScriptFieldInstance
 	{
 		ScriptField Field;
+		
 		ScriptFieldInstance()
 		{
 			memset(m_Data, 0, sizeof(m_Data));

--- a/CatEngine/src/CatEngine/Scripting/IScriptObject.h
+++ b/CatEngine/src/CatEngine/Scripting/IScriptObject.h
@@ -13,9 +13,11 @@ namespace CatEngine
     class IScriptObject
     {
     public:
-        virtual void Start() {};
-        virtual void Update(float ts) {};
         virtual ~IScriptObject() {}
+        virtual void Start() {}
+        virtual void Update(float ts) {}
+        virtual void OnCollisionEnter(const Entity& other) {}
+        virtual void OnCollisionExit(const Entity& other) {}
     protected:
         UUID m_UUID;
 

--- a/CatEngine/src/CatEngine/Scripting/ScriptClass.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptClass.cpp
@@ -219,11 +219,14 @@ namespace CatEngine
             }
             else
             {
-                std::string name;
-                ScriptField sf = GetField(m_Instance, line.c_str(), name);
-                if (!name.empty())
+                if (isPublicVariable)
                 {
-                    m_Fields[name] = sf;
+                    std::string name;
+                    ScriptField sf = GetField(m_Instance, line.c_str(), name);
+                    if (!name.empty())
+                    {
+                        m_Fields[name] = sf;
+                    }
                 }
             }
 

--- a/CatEngine/src/CatEngine/Scripting/ScriptClass.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptClass.cpp
@@ -1,7 +1,10 @@
+#include "CatEngine/Scripting/CatScriptCore.h"
 #include "cepch.h"
 #include "ScriptClass.h"
 
 #include "ScriptInstance.h"
+#include <cstdint>
+#include <cstring>
 
 #ifdef CE_PLATFORM_LINUX
 #include <dlfcn.h>
@@ -32,8 +35,8 @@ namespace CatEngine
 		{"Rigidbody2DComponent", ScriptFieldType::Rigidbody2DComponent},
 
 	};
-    
-    static bool IsVariable(const char* line, std::string& outVariableType, std::string& outVariableName)
+
+    static bool IsVariable(const char* line, std::string& outVariableType, std::string& outVariableName, void* outVariableValue)
     {
         for (auto& [keyword, sft] : s_ScriptFieldTypeMap)
         {
@@ -43,14 +46,18 @@ namespace CatEngine
                 outVariableType = keyword;
                 lineStr.erase(0, keyword.length());
                 size_t equalSign = lineStr.find_first_of('=');
-                outVariableName = lineStr.substr(0, equalSign);
+                if (equalSign == std::string::npos)
+                    outVariableName = lineStr.substr(0 , lineStr.length() - 1); // Erases ";" character
+                else
+                    outVariableName = lineStr.substr(0, equalSign);
+                
                 return true;
             }
         }
 
         return false;
     }
-		
+
     ScriptFieldType StringToScriptFieldType(const std::string& type)
     {
         auto it = s_ScriptFieldTypeMap.find(type);
@@ -62,7 +69,7 @@ namespace CatEngine
         return ScriptFieldType::None;
     }
 
-    void* GetVariableSymbol(void* handle, ScriptFieldType type, const std::string& symbolName)
+    void* GetVariableSymbol(CatScriptClass* handle, ScriptFieldType type, const std::string& symbolName)
     {
         void* out = nullptr;
 
@@ -92,16 +99,65 @@ namespace CatEngine
         return out;
 
     }
+
+    bool IsTrue(const std::string& value)
+    {
+        if (strncmp(value.c_str(), "true", 4) == 0)
+            return true;
+        return false;
+    }
+
+    ScriptField GetField(CatScriptClass* instance, const char* line, std::string& outName)
+    {
+        ScriptField sf;
+        std::string type, value;
+
+        std::string lineStr(line);
+
+        for (auto& [keyword, sft] : s_ScriptFieldTypeMap)
+        {
+            if (strncmp(line, keyword.c_str(), keyword.length()) == 0)
+            {
+                sf.Type = sft;
+                type = keyword;
+                lineStr.erase(0, keyword.length());
+                size_t equalSign = lineStr.find_first_of('=');
+                if (equalSign != std::string::npos)
+                    outName = lineStr.substr(0, equalSign);
+                else
+                    outName = lineStr.substr(0 , lineStr.length() - 1); // Erases ";" character
+
+                outName.erase(remove_if(outName.begin(), outName.end(), isspace), outName.end()); // Removes and folling and trailing spaces
+
+                sf.ClassField = GetVariableSymbol(instance, sft, outName);
+                if (sf.ClassField == nullptr)
+                {
+                    CE_API_CRITICAL("NULL DETECTED: {0}:{1}", type, outName);
+                    outName = "";
+                    return ScriptField();
+                }
+                break;
+            }
+        }
+        return sf;
+
+    }
+
     ScriptClass::ScriptClass(const std::filesystem::path& path)
         : m_Path(path)
     {
 #       ifdef CE_PLATFORM_LINUX
         m_Instance = dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
-#       endif
         CE_API_ASSERT(m_Instance, dlerror());
 
+        CE_API_WARN("Library Path : {}", path.string());
+
         m_CreateScript = (create_t*)dlsym(m_Instance, "create");
+        CE_API_ASSERT(m_CreateScript, dlerror());
         m_DestroyScript = (destroy_t*)dlsym(m_Instance, "destroy");
+        CE_API_ASSERT(m_DestroyScript, dlerror());
+
+#       endif
     }
 
     ScriptClass::~ScriptClass()
@@ -165,29 +221,16 @@ namespace CatEngine
             }
             else
             {
-                std::string variableType, variableName;
-                if (IsVariable(lineParse.c_str(), variableType, variableName) && isPublicVariable)
+                std::string name;
+                ScriptField sf = GetField(m_Instance, line.c_str(), name);
+                if (!name.empty())
                 {
-                    CE_API_INFO("{} - {}", variableType, variableName);
-                    variables.emplace(std::pair<std::string, std::string>(variableName, variableType));
+                    CE_API_INFO("{}", name);
+                    m_Fields[name] = sf;
                 }
             }
 
         }
     
-
-        for (auto& [name, type] : variables)
-        {
-            ScriptField sf;
-            sf.Type = StringToScriptFieldType(type);
-            sf.Name = name;
-            sf.ClassField = GetVariableSymbol(m_Instance, sf.Type, name);
-            if (sf.ClassField == nullptr)
-            {
-                CE_API_CRITICAL("NULL DETECTED: {0}:{1}", type, name);
-            }
-            m_Fields.emplace(std::pair<std::string, ScriptField>(name, sf));
-        }
-
     }
 }

--- a/CatEngine/src/CatEngine/Scripting/ScriptClass.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptClass.cpp
@@ -150,8 +150,6 @@ namespace CatEngine
         m_Instance = dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
         CE_API_ASSERT(m_Instance, dlerror());
 
-        CE_API_WARN("Library Path : {}", path.string());
-
         m_CreateScript = (create_t*)dlsym(m_Instance, "create");
         CE_API_ASSERT(m_CreateScript, dlerror());
         m_DestroyScript = (destroy_t*)dlsym(m_Instance, "destroy");
@@ -225,7 +223,6 @@ namespace CatEngine
                 ScriptField sf = GetField(m_Instance, line.c_str(), name);
                 if (!name.empty())
                 {
-                    CE_API_INFO("{}", name);
                     m_Fields[name] = sf;
                 }
             }

--- a/CatEngine/src/CatEngine/Scripting/ScriptEngine.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptEngine.cpp
@@ -138,11 +138,19 @@ namespace CatEngine
 	void ScriptEngine::OnRuntimeStop()
 	{
 		s_ScriptData->SceneContext = nullptr;
+        std::vector<UUID> scriptUUIDs;
         for (auto& [uuid, instance] : s_ScriptData->EntityInstances)
         {
             instance->InvokeDeleteScript();
-            instance = nullptr;
+            scriptUUIDs.push_back(uuid);
         }
+
+        for (auto& uuid : scriptUUIDs)
+        {
+            //s_ScriptData->EntityInstances[uuid]->ResetFieldData();
+        }
+
+
 		s_ScriptData->EntityInstances.clear();
 		
 		if (s_ScriptData->SourceFileReloadPending || !s_ScriptData->MainThreadQueue.empty())

--- a/CatEngine/src/CatEngine/Scripting/ScriptEngine.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptEngine.cpp
@@ -164,7 +164,9 @@ namespace CatEngine
             {
                 auto it = s_ScriptData->EntityClasses.find(fd.Name);
                 if (it != s_ScriptData->EntityClasses.end())
+                {
                     s_ScriptData->EntityClasses.erase(it);
+                }
                 s_ScriptData->EntityClasses[fd.Name] = CreateRef<ScriptClass>(fd.SharedObjectPath);
                 s_ScriptData->EntityClasses[fd.Name]->SetFieldsFromFile(fd.SourceFilePath);
             }

--- a/CatEngine/src/CatEngine/Scripting/ScriptEngine.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptEngine.cpp
@@ -1,3 +1,5 @@
+#include "CatEngine/Core/Core.h"
+#include "CatEngine/Core/Log.h"
 #include "cepch.h"
 #include "ScriptEngine.h"
 
@@ -138,16 +140,9 @@ namespace CatEngine
 	void ScriptEngine::OnRuntimeStop()
 	{
 		s_ScriptData->SceneContext = nullptr;
-        std::vector<UUID> scriptUUIDs;
         for (auto& [uuid, instance] : s_ScriptData->EntityInstances)
         {
             instance->InvokeDeleteScript();
-            scriptUUIDs.push_back(uuid);
-        }
-
-        for (auto& uuid : scriptUUIDs)
-        {
-            //s_ScriptData->EntityInstances[uuid]->ResetFieldData();
         }
 
 
@@ -231,6 +226,32 @@ namespace CatEngine
 		}
 
 	}
+
+    void ScriptEngine::DispatchCollisionEvent(UUID uuidA, UUID uuidB, CollisionType type)
+    {
+        Ref<ScriptInstance> scriptA, scriptB;
+        if (s_ScriptData->EntityInstances.find(uuidA) != s_ScriptData->EntityInstances.end())
+            scriptA = s_ScriptData->EntityInstances[uuidA];
+
+        if (s_ScriptData->EntityInstances.find(uuidB) != s_ScriptData->EntityInstances.end())
+            scriptB = s_ScriptData->EntityInstances[uuidB];
+
+        const auto& entityA = s_ScriptData->SceneContext->GetEntityByUUID(uuidA);
+        const auto& entityB = s_ScriptData->SceneContext->GetEntityByUUID(uuidB);
+
+        switch (type)
+        {
+            case CollisionType::Begin:
+                if (scriptA) scriptA->InvokeOnCollisionEnter(entityB);
+                if (scriptB) scriptB->InvokeOnCollisionEnter(entityA);
+                break;
+            case CollisionType::End:
+                if (scriptA) scriptA->InvokeOnCollisionExit(entityB);
+                if (scriptB) scriptB->InvokeOnCollisionExit(entityA);
+                break;
+            default: break;
+        }
+    }
 
 	Ref<Scene> ScriptEngine::GetSceneContext()
 	{

--- a/CatEngine/src/CatEngine/Scripting/ScriptEngine.h
+++ b/CatEngine/src/CatEngine/Scripting/ScriptEngine.h
@@ -10,6 +10,13 @@
 
 namespace CatEngine
 {
+
+    enum class CollisionType
+    {
+        None = 0,
+        Begin, End,
+    };
+
     class Scene;
     class Entity;
 
@@ -31,6 +38,8 @@ namespace CatEngine
 		static bool ScriptClassExists(const std::string& fullClassName);
 		static void OnStartEntity(Entity e);
 		static void OnUpdateEntity(Entity e, float ts);
+
+        static void DispatchCollisionEvent(UUID entityA, UUID entityB, CollisionType type);
 
 		static Ref<Scene> GetSceneContext();
 		static Ref<ScriptInstance> GetEntityScriptInstance(UUID entityID);

--- a/CatEngine/src/CatEngine/Scripting/ScriptInstance.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptInstance.cpp
@@ -1,7 +1,9 @@
+#include "CatEngine/Core/Core.h"
 #include "cepch.h"
 #include "ScriptInstance.h"
 
 #include "ScriptClass.h"
+#include <cstring>
 
 namespace CatEngine
 {
@@ -9,8 +11,37 @@ namespace CatEngine
 		: m_ScriptClass(scriptClass)
 	{ 
 		m_Instance = scriptClass->Instantiate();
+        for (auto& [name, field] :scriptClass->GetFields())
+        {
+            size_t valueSize = TypeToSize(field.Type);
+            void* copy = malloc(valueSize);
+            if (copy == nullptr)
+            {
+                CE_API_ASSERT(false, "Failed to malloc data! : NAME - {}", name);
+            }
+
+            memcpy(copy, field.ClassField, valueSize);
+
+            if(copy == nullptr)
+            {
+                CE_API_ASSERT(false, "Failed to memcpy data! : NAME - {}", name);
+            }
+
+            m_DefaultFieldDatas[name] = copy;
+        }
 
 	}
+
+    ScriptInstance::~ScriptInstance()
+    {
+        for (auto& [name, data] : m_DefaultFieldDatas)
+        {
+            SetFieldDataInternal(name, data);
+            free(data);
+        }
+
+        m_DefaultFieldDatas.clear();
+    }
 
     void ScriptInstance::SetEntityID(UUID entityID)
     {

--- a/CatEngine/src/CatEngine/Scripting/ScriptInstance.cpp
+++ b/CatEngine/src/CatEngine/Scripting/ScriptInstance.cpp
@@ -1,4 +1,5 @@
 #include "CatEngine/Core/Core.h"
+#include "CatEngine/Scene/Entity.h"
 #include "cepch.h"
 #include "ScriptInstance.h"
 
@@ -61,8 +62,17 @@ namespace CatEngine
     {
         m_ScriptClass->DeleteScript(m_Instance);
     }
+    void ScriptInstance::InvokeOnCollisionEnter(const Entity& other)
+    {
+        m_Instance->OnCollisionEnter(other);
+    }
 
-	bool ScriptInstance::GetFieldDataInternal(const std::string& name, void* buffer)
+    void ScriptInstance::InvokeOnCollisionExit(const Entity& other)
+    {
+        m_Instance->OnCollisionExit(other);
+    }
+	
+    bool ScriptInstance::GetFieldDataInternal(const std::string& name, void* buffer)
     {
         const auto& fields = m_ScriptClass->GetFields();
         auto it = fields.find(name);

--- a/CatEngine/src/CatEngine/Scripting/ScriptInstance.h
+++ b/CatEngine/src/CatEngine/Scripting/ScriptInstance.h
@@ -18,6 +18,9 @@ namespace CatEngine
 		void InvokeStartMethod();
         void InvokeDeleteScript();
 
+        void InvokeOnCollisionEnter(const Entity& other);
+        void InvokeOnCollisionExit(const Entity& other);
+
 		Ref<ScriptClass> GetScriptClass() { return m_ScriptClass; }
 
 		template<typename T>

--- a/CatEngine/src/CatEngine/Scripting/ScriptInstance.h
+++ b/CatEngine/src/CatEngine/Scripting/ScriptInstance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CatScriptCore.h"
+#include <unordered_map>
 
 namespace CatEngine
 {
@@ -9,6 +10,7 @@ namespace CatEngine
 	{
 	public:
 		ScriptInstance(Ref<ScriptClass> scriptClass, Entity entity);
+        ~ScriptInstance();
 
         void SetEntityID(UUID entityID);
 
@@ -43,6 +45,8 @@ namespace CatEngine
 		Ref<ScriptClass> m_ScriptClass;
 
 		CatScriptObject* m_Instance = nullptr;
+
+        std::unordered_map<std::string, void*> m_DefaultFieldDatas;
 
 		static inline char s_FieldValueBuffer[8];
 

--- a/CatEngine/src/CatEngine/Scripting/SourceFileCompiler.cpp
+++ b/CatEngine/src/CatEngine/Scripting/SourceFileCompiler.cpp
@@ -204,7 +204,9 @@ namespace CatEngine
         bool firstLoopInClass = true;
 
         int openingBrackets = 0, closingBrackets = 0;
-        while (getline(copy, line))
+        std::string className;
+
+        while (std::getline(copy, line))
         {
             std::string lineParse = line;
             lineParse.erase(remove_if(lineParse.begin(), lineParse.end(), isspace), lineParse.end());
@@ -212,6 +214,8 @@ namespace CatEngine
             if (strncmp(lineParse.c_str(), "class", 5) == 0)
             {
                 inClass = true;
+                size_t eow = lineParse.find(":", 5);
+                className = lineParse.substr(5, eow - 5);
             }
 
             if (inClass)
@@ -245,6 +249,10 @@ namespace CatEngine
 
             out << line << "\n";
         }
+
+        out << "extern \"C\" CatEngine::IScriptObject* create() { return new " << className << "; }\n"
+            << "extern \"C\" void destroy(CatEngine::IScriptObject* script) { delete script; }";
+
         out.close();
 
         std::string fileName = filePath.filename();
@@ -273,6 +281,7 @@ namespace CatEngine
         {
             m_CompiledFiles.push_back(fd);
         }
+
 
         std::ofstream out1(filePath, std::ios::out | std::ios::trunc);
         if (!out1.is_open())
@@ -317,25 +326,23 @@ namespace CatEngine
 
     void SourceFileCompiler::CompileFile(FileDescription fd)
     {
-            Application::Get().SubmitToMainThread([fd](){
-                std::stringstream ss;
-                ss << "cd " << Project::GetAssetDirectory() << "; " << GetBuildCommandVariables(fd);
-                system(ss.str().c_str());
+        std::stringstream ss;
+        ss << "cd " << Project::GetAssetDirectory() << "; " << GetBuildCommandVariables(fd);
+        system(ss.str().c_str());
 
-                bool fileExists = false;
+        bool fileExists = false;
 
-                for (auto& file : m_CompiledFiles)
-                {
-                    if (fd.Name == file.Name)
-                    {
-                        fileExists = true;
-                        break;
-                    }
-                }
+        for (auto& file : m_CompiledFiles)
+        {
+            if (fd.Name == file.Name)
+            {
+                fileExists = true;
+                break;
+            }
+        }
 
-                if (!fileExists)
-                    m_CompiledFiles.push_back(fd);
-            });
+        if (!fileExists)
+            m_CompiledFiles.push_back(fd);
 
     }
 

--- a/CatEngine/src/CatEngine/Scripting/SourceFileCompiler.cpp
+++ b/CatEngine/src/CatEngine/Scripting/SourceFileCompiler.cpp
@@ -314,6 +314,7 @@ namespace CatEngine
            << "-I" << CatEngineVND << "/glm \\\n"
            << "-I" << CatEngineVND << "/entt \\\n"
            << "-I" << CatEngineVND << "/Glad/include \\\n"
+           << "-I" << CatEngineVND << "/Box2D/include \\\n"
            << "-DCE_SCRIPT_COMPILATION \\\n"
            << "-fPIC; \n";
      

--- a/imgui.ini
+++ b/imgui.ini
@@ -59,13 +59,13 @@ DockId=0x0000000D,0
 
 [Window][Viewport]
 Pos=277,53
-Size=409,421
+Size=221,421
 Collapsed=0
 DockId=0x0000000D,0
 
 [Window][Main Camera (preview)]
-Pos=688,53
-Size=192,421
+Pos=500,53
+Size=380,421
 Collapsed=0
 DockId=0x0000000E,0
 
@@ -121,8 +121,8 @@ DockSpace           ID=0x04726DD8 Window=0x004E1B88 Pos=0,20 Size=1280,699 Split
       DockNode      ID=0x00000009 Parent=0x00000001 SizeRef=1512,427 Split=X
         DockNode    ID=0x0000000B Parent=0x00000009 SizeRef=275,427 Selected=0x29EABFBD
         DockNode    ID=0x0000000C Parent=0x00000009 SizeRef=603,427 Split=X
-          DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=409,427 CentralNode=1 Selected=0x13926F0B
-          DockNode  ID=0x0000000E Parent=0x0000000C SizeRef=192,427 Selected=0x9B9D255D
+          DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=221,427 CentralNode=1 Selected=0x13926F0B
+          DockNode  ID=0x0000000E Parent=0x0000000C SizeRef=380,427 Selected=0x9B9D255D
       DockNode      ID=0x0000000A Parent=0x00000001 SizeRef=398,427 Selected=0xE7039252
     DockNode        ID=0x00000002 Parent=0x00000008 SizeRef=1280,243 Split=X Selected=0xFF2336B5
       DockNode      ID=0x0000000F Parent=0x00000002 SizeRef=313,280 Selected=0xFF2336B5

--- a/imgui.ini
+++ b/imgui.ini
@@ -42,12 +42,12 @@ Collapsed=0
 
 [Window][MyDockSpace]
 Pos=0,0
-Size=1280,720
+Size=3840,2094
 Collapsed=0
 
 [Window][Console]
-Pos=0,476
-Size=313,243
+Pos=0,1850
+Size=940,243
 Collapsed=0
 DockId=0x0000000F,1
 
@@ -59,37 +59,37 @@ DockId=0x0000000D,0
 
 [Window][Viewport]
 Pos=277,53
-Size=221,421
+Size=2598,1795
 Collapsed=0
 DockId=0x0000000D,0
 
 [Window][Main Camera (preview)]
-Pos=500,53
-Size=380,421
+Pos=2877,53
+Size=563,1795
 Collapsed=0
 DockId=0x0000000E,0
 
 [Window][Hierarchy]
 Pos=0,53
-Size=275,421
+Size=275,1795
 Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Inspector]
-Pos=882,53
-Size=398,421
+Pos=3442,53
+Size=398,1795
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][Assets]
-Pos=315,476
-Size=965,243
+Pos=942,1850
+Size=2898,243
 Collapsed=0
 DockId=0x00000010,0
 
 [Window][##toolbar]
 Pos=0,20
-Size=1280,31
+Size=3840,31
 Collapsed=0
 DockId=0x00000007
 
@@ -104,8 +104,8 @@ Size=345,124
 Collapsed=0
 
 [Window][File Browser]
-Pos=0,476
-Size=313,243
+Pos=0,1850
+Size=940,243
 Collapsed=0
 DockId=0x0000000F,0
 
@@ -114,15 +114,15 @@ Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
 [Docking][Data]
-DockSpace           ID=0x04726DD8 Window=0x004E1B88 Pos=0,20 Size=1280,699 Split=Y Selected=0x49278EEE
+DockSpace           ID=0x04726DD8 Window=0x004E1B88 Pos=0,20 Size=3840,2073 Split=Y Selected=0x49278EEE
   DockNode          ID=0x00000007 Parent=0x04726DD8 SizeRef=1280,31 Selected=0xF0F70764
   DockNode          ID=0x00000008 Parent=0x04726DD8 SizeRef=1280,670 Split=Y
     DockNode        ID=0x00000001 Parent=0x00000008 SizeRef=1280,421 Split=X Selected=0x08AA43A5
       DockNode      ID=0x00000009 Parent=0x00000001 SizeRef=1512,427 Split=X
         DockNode    ID=0x0000000B Parent=0x00000009 SizeRef=275,427 Selected=0x29EABFBD
         DockNode    ID=0x0000000C Parent=0x00000009 SizeRef=603,427 Split=X
-          DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=221,427 CentralNode=1 Selected=0x13926F0B
-          DockNode  ID=0x0000000E Parent=0x0000000C SizeRef=380,427 Selected=0x9B9D255D
+          DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=2598,427 CentralNode=1 Selected=0x13926F0B
+          DockNode  ID=0x0000000E Parent=0x0000000C SizeRef=563,427 Selected=0x9B9D255D
       DockNode      ID=0x0000000A Parent=0x00000001 SizeRef=398,427 Selected=0xE7039252
     DockNode        ID=0x00000002 Parent=0x00000008 SizeRef=1280,243 Split=X Selected=0xFF2336B5
       DockNode      ID=0x0000000F Parent=0x00000002 SizeRef=313,280 Selected=0xFF2336B5

--- a/imgui.ini
+++ b/imgui.ini
@@ -42,12 +42,12 @@ Collapsed=0
 
 [Window][MyDockSpace]
 Pos=0,0
-Size=3840,2094
+Size=1280,720
 Collapsed=0
 
 [Window][Console]
-Pos=0,1850
-Size=940,243
+Pos=0,476
+Size=457,243
 Collapsed=0
 DockId=0x0000000F,1
 
@@ -59,37 +59,37 @@ DockId=0x0000000D,0
 
 [Window][Viewport]
 Pos=277,53
-Size=2598,1795
+Size=32,421
 Collapsed=0
 DockId=0x0000000D,0
 
 [Window][Main Camera (preview)]
-Pos=2877,53
-Size=563,1795
+Pos=311,53
+Size=569,421
 Collapsed=0
 DockId=0x0000000E,0
 
 [Window][Hierarchy]
 Pos=0,53
-Size=275,1795
+Size=275,421
 Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Inspector]
-Pos=3442,53
-Size=398,1795
+Pos=882,53
+Size=398,421
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][Assets]
-Pos=942,1850
-Size=2898,243
+Pos=459,476
+Size=821,243
 Collapsed=0
 DockId=0x00000010,0
 
 [Window][##toolbar]
 Pos=0,20
-Size=3840,31
+Size=1280,31
 Collapsed=0
 DockId=0x00000007
 
@@ -104,8 +104,8 @@ Size=345,124
 Collapsed=0
 
 [Window][File Browser]
-Pos=0,1850
-Size=940,243
+Pos=0,476
+Size=457,243
 Collapsed=0
 DockId=0x0000000F,0
 
@@ -114,19 +114,19 @@ Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
 [Docking][Data]
-DockSpace           ID=0x04726DD8 Window=0x004E1B88 Pos=0,20 Size=3840,2073 Split=Y Selected=0x49278EEE
+DockSpace           ID=0x04726DD8 Window=0x004E1B88 Pos=0,20 Size=1280,699 Split=Y Selected=0x49278EEE
   DockNode          ID=0x00000007 Parent=0x04726DD8 SizeRef=1280,31 Selected=0xF0F70764
   DockNode          ID=0x00000008 Parent=0x04726DD8 SizeRef=1280,670 Split=Y
     DockNode        ID=0x00000001 Parent=0x00000008 SizeRef=1280,421 Split=X Selected=0x08AA43A5
       DockNode      ID=0x00000009 Parent=0x00000001 SizeRef=1512,427 Split=X
         DockNode    ID=0x0000000B Parent=0x00000009 SizeRef=275,427 Selected=0x29EABFBD
         DockNode    ID=0x0000000C Parent=0x00000009 SizeRef=603,427 Split=X
-          DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=2598,427 CentralNode=1 Selected=0x13926F0B
-          DockNode  ID=0x0000000E Parent=0x0000000C SizeRef=563,427 Selected=0x9B9D255D
+          DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=2415,427 CentralNode=1 Selected=0x13926F0B
+          DockNode  ID=0x0000000E Parent=0x0000000C SizeRef=746,427 Selected=0x9B9D255D
       DockNode      ID=0x0000000A Parent=0x00000001 SizeRef=398,427 Selected=0xE7039252
     DockNode        ID=0x00000002 Parent=0x00000008 SizeRef=1280,243 Split=X Selected=0xFF2336B5
-      DockNode      ID=0x0000000F Parent=0x00000002 SizeRef=313,280 Selected=0xFF2336B5
-      DockNode      ID=0x00000010 Parent=0x00000002 SizeRef=965,280 Selected=0x26CE0345
+      DockNode      ID=0x0000000F Parent=0x00000002 SizeRef=457,280 Selected=0xFF2336B5
+      DockNode      ID=0x00000010 Parent=0x00000002 SizeRef=821,280 Selected=0x26CE0345
 DockSpace           ID=0x3BC79352 Pos=0,17 Size=1600,883 Split=X
   DockNode          ID=0x00000005 Parent=0x3BC79352 SizeRef=892,883 Split=Y
     DockNode        ID=0x00000003 Parent=0x00000005 SizeRef=1600,626 CentralNode=1 Selected=0xE1FDE0B9


### PR DESCRIPTION
Users are now able to load CatEditor without source files recompiling

- Opening CatEditor is now much faster
- Source files won't recompile immediately unless the library file is deleted

Script Fields now properly reset after ending runtime

- Small bugfix, Script fields would retain their data set in runtime. This is now resolved.

Added basic collision events

- Now able to use commands OnCollisionEnter & OnCollisionExit with const Entity& other as the parameter for both.

What to expect as far as scripting in the future?

- More collision events
- Component fields (in SceneHierarchyPanel)